### PR TITLE
Refine PerEpoch container and busy-waiting persister

### DIFF
--- a/src/persist/ToBePersistedContainers.hpp
+++ b/src/persist/ToBePersistedContainers.hpp
@@ -61,13 +61,15 @@ class PerEpoch : public ToBePersistContainer{
         struct Signal {
             std::mutex bell;
             std::condition_variable ring;
-            int curr = 0;
             uint64_t epoch = INIT_EPOCH;
+            std::atomic<uint64_t> finish_counter;
         }__attribute__((aligned(CACHE_LINE_SIZE)));
-
+        
         GlobalTestConfig* gtc;
         std::vector<std::thread> persisters;
         std::vector<hwloc_obj_t> persister_affinities;
+        uint64_t last_persisted = NULL_EPOCH;
+        
         std::atomic<bool> exit;
         Signal signal;
         // TODO: explain in comment what's going on here.


### PR DESCRIPTION
1. got rid of signal counter `curr` in `Signal` struct of `PerEpoch::PerThreadDedicatedWait`.
    (I believe similar signal structs in other persisters are less redundant, so I kept them)
2. added waiting mechanism for the persister of `PerEpoch` container.
3. for the busy-waiting persister of `BufferedWB`, I moved ack to the end of persister threads' loop so that the dump will not happen concurrently with epoch advancer's clean-up of the epoch.