### PR TITLE
refined sync() and flush()

### DIFF
--- a/src/persist/EpochSys.cpp
+++ b/src/persist/EpochSys.cpp
@@ -217,7 +217,6 @@ namespace pds{
 
     // TODO: put epoch advancing logic into epoch advancers.
     void EpochSys::advance_epoch_dedicated(){
-        std::lock_guard<std::mutex> lock(dedicated_epoch_advancer_lock);
         uint64_t c = global_epoch->load(std::memory_order_relaxed);
         // Free all retired blocks from 2 epochs ago
         to_be_freed->help_free(c-2);
@@ -225,10 +224,10 @@ namespace pds{
         while(!trans_tracker->no_active(c-1)){}
         // Persist all modified blocks from 1 epoch ago
         to_be_persisted->persist_epoch(c-1);
-        // persist_func::sfence(); // given the length of current epoch, we may not need this.
+        persist_func::sfence();
         // Actually advance the epoch
         // global_epoch->compare_exchange_strong(c, c+1, std::memory_order_seq_cst);
-        global_epoch->store(c+1, std::memory_order_relaxed);
+        global_epoch->store(c+1, std::memory_order_seq_cst);
 
         //if (c % 10000 == 0){
         //    std::cout<<"epoch:"<<c<<std::endl;

--- a/src/persist/EpochSys.hpp
+++ b/src/persist/EpochSys.hpp
@@ -145,8 +145,6 @@ public:
     /* static */
     static thread_local int tid;
     
-    std::mutex dedicated_epoch_advancer_lock;
-
     // system mode that toggles on/off PDELETE for recovery purpose.
     SysMode sys_mode = ONLINE;
 
@@ -158,18 +156,18 @@ public:
     }
 
     void flush(){
-        for (int i = 0; i < 4; i++){
-            advance_epoch_dedicated();
+        for (int i = 0; i < 2; i++){
+            sync(NULL_EPOCH);
         }
     }
 
     ~EpochSys(){
         // std::cout<<"epochsys descructor called"<<std::endl;
         trans_tracker->finalize();
+        flush();
         if (epoch_advancer){
             delete epoch_advancer;
         }
-        flush();
         // std::cout<<"final epoch:"<<global_epoch->load()<<std::endl;
         delete trans_tracker;
         delete to_be_persisted;


### PR DESCRIPTION
1. added fence to `epoch_advance_dedicated`
2. got rid of the lock for `epoch_advance_dedicated`. Using two `sync()` instead.
3. if `sync()` 's target epoch is persisted, return immideately.
4. `sync()` should NOT be called by threads in operations, since epoch advance waits for operations to complete.
5. unlock signal when doing epoch advance, to allow concurrency between epoch advancers and worker threads.