### PR TITLE
Allow odd number of threads in Mindicator

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,7 +173,6 @@ int main(int argc, char *argv[])
 	gtc.addTestOption(new QueueChurnTest(50,50,2000), "QueueChurn:eq50dq50:prefill=2000");
 	gtc.addTestOption(new QueueTest(5000000,50), "Queue:5m");
 	gtc.addTestOption(new MapChurnTest<string,string>(0, 0, 50, 50, 1000000, 500000), "MapChurnTest<string>:g0p0i50rm50:range=1000000:prefill=500000");
-	gtc.addTestOption(new MapChurnTest<string,string>(0, 50, 0, 50, 1000000, 500000), "MapChurnTest<string>:g0p50i0rm50:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapChurnTest<string,string>(50, 0, 25, 25, 1000000, 500000), "MapChurnTest<string>:g50p0i25rm25:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapChurnTest<string,string>(90, 0, 5, 5, 1000000, 500000), "MapChurnTest<string>:g90p0i5rm5:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapTest<string,string>(0, 0, 50, 50, 1000000, 500000, 10000000), "MapTest<string>:g0p0i50rm50:range=1000000:prefill=500000:op=10000000");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,6 +173,7 @@ int main(int argc, char *argv[])
 	gtc.addTestOption(new QueueChurnTest(50,50,2000), "QueueChurn:eq50dq50:prefill=2000");
 	gtc.addTestOption(new QueueTest(5000000,50), "Queue:5m");
 	gtc.addTestOption(new MapChurnTest<string,string>(0, 0, 50, 50, 1000000, 500000), "MapChurnTest<string>:g0p0i50rm50:range=1000000:prefill=500000");
+	gtc.addTestOption(new MapChurnTest<string,string>(0, 50, 0, 50, 1000000, 500000), "MapChurnTest<string>:g0p50i0rm50:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapChurnTest<string,string>(50, 0, 25, 25, 1000000, 500000), "MapChurnTest<string>:g50p0i25rm25:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapChurnTest<string,string>(90, 0, 5, 5, 1000000, 500000), "MapChurnTest<string>:g90p0i5rm5:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapTest<string,string>(0, 0, 50, 50, 1000000, 500000, 10000000), "MapTest<string>:g0p0i50rm50:range=1000000:prefill=500000:op=10000000");

--- a/src/persist/PersistTrackers.hpp
+++ b/src/persist/PersistTrackers.hpp
@@ -202,7 +202,8 @@ public:
             }
         }
         // always use thread_cnt >= 2 to make sure tree is full.
-        int thread_cnt = actual_thread_cnt == 1? 2 : actual_thread_cnt;
+        int thread_cnt = actual_thread_cnt % 2 == 1?
+            actual_thread_cnt+1 : actual_thread_cnt;
         leaves = new Node[thread_cnt];
         for (int i = 0; i < thread_cnt; i++){
             leaves[i].leaf_idx = i;
@@ -239,8 +240,8 @@ public:
             *buffer.front() = &leaves[i];
             buffer.pop_front();
         }
-        if (actual_thread_cnt == 1){
-            root->children[1]->marked_val = {UINT64_MAX, 0};
+        if (actual_thread_cnt % 2 == 1){
+            leaves[thread_cnt-1].marked_val = {UINT64_MAX, 0};
         }
         // traverse the tree and init the tree.
         std::vector<Node*> path;
@@ -405,7 +406,8 @@ class IncreasingMindicator : public PersistTracker{
 public:
     IncreasingMindicator(int actual_thread_cnt){
         assert(actual_thread_cnt > 0);
-        int thread_cnt = actual_thread_cnt == 1? 2 : actual_thread_cnt;
+        int thread_cnt = actual_thread_cnt % 2 == 1?
+            actual_thread_cnt+1 : actual_thread_cnt;
         leaves = new Node[thread_cnt];
         for (int i = 0; i < thread_cnt; i++){
             leaves[i].leaf_idx = i;
@@ -442,8 +444,8 @@ public:
             *buffer.front() = &leaves[i];
             buffer.pop_front();
         }
-        if (actual_thread_cnt == 1){
-            root->children[1]->val = UINT64_MAX;
+        if (actual_thread_cnt % 2 == 1){
+            leaves[thread_cnt-1].val = UINT64_MAX;
         }
         // traverse the tree and init the tree.
         std::vector<Node*> path;


### PR DESCRIPTION
Mindicator used to crash when the thread count is odd due to a stupid bug in its constructor. It's fixed now.