### PR TITLE
make Recoverable recover automatically

### DIFF
--- a/ext/ralloc/src/ralloc.hpp
+++ b/ext/ralloc/src/ralloc.hpp
@@ -85,6 +85,9 @@ public:
         for(int i=0;i<thd_num;i++){
             new (&(t_caches[i])) TCaches();
         }
+        set_fake_dirty();
+    }
+    inline void set_fake_dirty(){
         base_md->fake_dirty = true;
     }
     inline size_t malloc_size(void* ptr){

--- a/src/TestConfig.cpp
+++ b/src/TestConfig.cpp
@@ -418,7 +418,7 @@ void GlobalTestConfig::buildAffinity(std::vector<hwloc_obj_t>& aff){
 		buildDefaultAffinity(aff);
 	}
 	// extendAffinity() shoud be called to cover oversubscription.
-	assert(aff.size() >= task_num);
+	assert(aff.size() >= (uint64_t)task_num);
 }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -186,12 +186,12 @@ int main(int argc, char *argv[])
 	gtc.addTestOption(new MapChurnTest<uint64_t,uint64_t>(50, 0, 25, 25, 1000000, 500000), "MapChurnTest<uint64_t>:g50p0i25rm25:range=1000000:prefill=500000");
 	gtc.addTestOption(new MapVerify<string, string>(50, 0, 25, 25, 1000000, 10000), "MapVerify");
 #ifndef MNEMOSYNE
-	gtc.addTestOption(new RecoverVerifyTest<string,string>(), "RecoverVerifyTest");
+	gtc.addTestOption(new RecoverVerifyTest<string,string>(&gtc), "RecoverVerifyTest");
 
 	gtc.addTestOption(new GraphTest(numVertices, meanEdgesPerVertex,vertexLoad,8000), "GraphTest:80edge20vertex:degree32");
 	gtc.addTestOption(new GraphTest(numVertices, meanEdgesPerVertex,vertexLoad,9980), "GraphTest:99.8edge.2vertex:degree32");
 	// gtc.addTestOption(new GraphRecoveryTest("graph_data/", "orkut-edge-list_", 28610, 5, true), "GraphRecoveryTest:Orkut:verify");
-    gtc.addTestOption(new GraphRecoveryTest("graph_data/", "orkut-edge-list_", 28610, 5, false), "GraphRecoveryTest:Orkut:noverify");
+    gtc.addTestOption(new GraphRecoveryTest(&gtc, "graph_data/", "orkut-edge-list_", 28610, 5, false), "GraphRecoveryTest:Orkut:noverify");
     gtc.addTestOption(new TGraphConstructionTest("graph_data/", "orkut-edge-list_", 28610, 5), "TGraphConstructionTest:Orkut");
 #endif /* !MNEMOSYNE */
 	gtc.addTestOption(new AllocTest(1024 * 1024, DO_JEMALLOC_ALLOC), "AllocTest-JEMalloc");

--- a/src/persist/EpochSys.cpp
+++ b/src/persist/EpochSys.cpp
@@ -441,7 +441,6 @@ namespace pds{
                 thread_local std::unordered_set<uint64_t> deleted_ids_local;
                 // make the first whole pass thorugh all blocks, find the epoch block
                 // and help Ralloc fully recover by completing the pass.
-                uint64_t ralloc_itrs = 0;
                 for (; !itr_raw[rec_tid].is_last(); ++itr_raw[rec_tid]){
                     PBlk* curr_blk = (PBlk*) *itr_raw[rec_tid];
                     if (curr_blk->blktype == EPOCH){
@@ -458,13 +457,11 @@ namespace pds{
                         }
                     }
                     max_epoch_local = std::max(max_epoch_local, curr_blk->get_epoch());
-                    ralloc_itrs++;
                 }
                 // report after the first pass:
                 // calculate the maximum epoch number as the current epoch.
                 pthread_barrier_wait(&sync_point);
                 if (!epoch_container){
-                    cout<<"ralloc itrs:"<<ralloc_itrs<<endl;
                     errexit("epoch container not found during recovery");
                 }
                 while(curr_reporting.load() != rec_tid);

--- a/src/persist/EpochSys.cpp
+++ b/src/persist/EpochSys.cpp
@@ -653,141 +653,12 @@ namespace pds{
         global_epoch->store(max_epoch);
         // set system mode back to online
         sys_mode = ONLINE;
-        reset();
+
+        // we postpone reset until init()
 
         std::cout<<"returning from EpochSys Recovery."<<std::endl;
 #endif /* !MNEMOSYNE */
         return in_use;
-    }
-
-    void nbEpochSys::reset(){
-        EpochSys::reset();
-        // TODO: only nbEpochSys needs persistent descs. consider move all
-        // inits into nbEpochSys.
-        for (int i = 0; i < gtc->task_num; i++) {
-            to_be_persisted->init_desc_local(local_descs[i], i);
-        }
-    }
-
-    void nbEpochSys::parse_env(){
-        if (epoch_advancer){
-            delete epoch_advancer;
-        }
-        if (trans_tracker){
-            delete trans_tracker;
-        }
-        if (to_be_persisted) {
-            delete to_be_persisted;
-        }
-        if (to_be_freed) {
-            delete to_be_freed;
-        }
-
-        if (!gtc->checkEnv("EpochLengthUnit")){
-            gtc->setEnv("EpochLengthUnit", "Millisecond");
-        }
-
-        if (!gtc->checkEnv("EpochLength")){
-            gtc->setEnv("EpochLength", "50");
-        }
-
-        if (!gtc->checkEnv("BufferSize")){
-            gtc->setEnv("BufferSize", "64");
-        }
-
-        if (gtc->checkEnv("PersistStrat")){
-            if (gtc->getEnv("PersistStrat") == "No"){
-                to_be_persisted = new NoToBePersistContainer();
-                to_be_freed = new NoToBeFreedContainer(this);
-                epoch_advancer = new NoEpochAdvancer();
-                trans_tracker = new NoTransactionTracker(this->global_epoch);
-                persisted_epochs = new IncreasingMindicator(task_num);
-                return;
-            }
-        }
-
-        if (gtc->checkEnv("PersistStrat")){
-            string env_persist = gtc->getEnv("PersistStrat");
-            if (env_persist == "DirWB"){
-                to_be_persisted = new DirWB(_ral, gtc->task_num);
-            } else if (env_persist == "PerEpoch"){
-                errexit("nbEpochSys isn't compatible with PerEpoch!");
-            } else if (env_persist == "BufferedWB"){
-                to_be_persisted = new BufferedWB(gtc, _ral);
-            } else {
-                errexit("unrecognized 'persist' environment");
-            }
-        } else {
-            gtc->setEnv("PersistStrat", "BufferedWB");
-            to_be_persisted = new BufferedWB(gtc, _ral);
-        }
-
-        if (gtc->checkEnv("Free")){
-            string env_free = gtc->getEnv("Free");
-            if (env_free == "PerEpoch"){
-                to_be_freed = new PerEpochFreedContainer(this, gtc);
-            } else if (env_free == "No"){
-                to_be_freed = new NoToBeFreedContainer(this);
-            } else {
-                errexit("unrecognized 'free' environment");
-            }
-        } else {
-            to_be_freed = new PerEpochFreedContainer(this, gtc);
-        }
-
-        if (gtc->checkEnv("TransTracker")){
-            string env_transcounter = gtc->getEnv("TransTracker");
-            if (env_transcounter == "AtomicCounter"){
-                trans_tracker = new AtomicTransactionTracker(this->global_epoch);
-            } else if (env_transcounter == "ActiveThread"){
-                trans_tracker = new FenceBeginTransactionTracker(this->global_epoch, task_num);
-            } else if (env_transcounter == "CurrEpoch"){
-                trans_tracker = new PerEpochTransactionTracker(this->global_epoch, task_num);
-            } else {
-                errexit("unrecognized 'transaction counter' environment");
-            }
-        } else {
-            trans_tracker = new PerEpochTransactionTracker(this->global_epoch, task_num);
-        }
-
-        if (gtc->checkEnv("PersistTracker")){
-            string env_persisttracker = gtc->getEnv("PersistTracker");
-            if (env_persisttracker == "IncreasingMindicator"){
-                persisted_epochs = new IncreasingMindicator(task_num);
-            } else if (env_persisttracker == "Mindicator"){
-                persisted_epochs = new Mindicator(task_num);
-            } else {
-                errexit("unrecognized 'persist tracker' environment");
-            }
-        } else {
-            persisted_epochs = new IncreasingMindicator(task_num);
-        }
-
-        epoch_advancer = new DedicatedEpochAdvancerNbSync(gtc, this);
-
-        // if (gtc->checkEnv("EpochAdvance")){
-        //     string env_epochadvance = gtc->getEnv("EpochAdvance");
-        //     if (env_epochadvance == "Global"){
-        //         epoch_advancer = new GlobalCounterEpochAdvancer();
-        //     } else if (env_epochadvance == "SingleThread"){
-        //         epoch_advancer = new SingleThreadEpochAdvancer(gtc);
-        //     } else if (env_epochadvance == "Dedicated"){
-        //         epoch_advancer = new DedicatedEpochAdvancer(gtc, this);
-        //     } else {
-        //         errexit("unrecognized 'epoch advance' argument");
-        //     }
-        // } else {
-        //     gtc->setEnv("EpochAdvance", "Dedicated");
-        //     epoch_advancer = new DedicatedEpochAdvancer(gtc, this);
-        // }
-
-        // if (gtc->checkEnv("EpochFreq")){
-        //     int env_epoch_advance = stoi(gtc->getEnv("EpochFreq"));
-        //     if (gtc->getEnv("EpochAdvance") != "Dedicated" && env_epoch_advance > 63){
-        //         errexit("invalid EpochFreq power");
-        //     }
-        //     epoch_advancer->set_epoch_freq(env_epoch_advance);
-        // }
     }
 
     void nbEpochSys::register_alloc_pblk(PBlk* b, uint64_t c){
@@ -1054,6 +925,10 @@ namespace pds{
                         uint64_t curr_tid = tmp->get_tid();
                         max_tid_local = std::max(max_tid_local, curr_tid);
                         descs_local[curr_tid] = tmp;
+                        if(curr_tid<(uint64_t)task_num) {
+                            assert(local_descs[curr_tid]==nullptr);
+                            local_descs[curr_tid] = tmp;
+                        }
                     } else if (curr_blk->blktype == DELETE) {
                         anti_nodes_local.push_back(curr_blk);
                         if (curr_blk->get_epoch() != NULL_EPOCH){
@@ -1183,9 +1058,7 @@ namespace pds{
                             } break;
                             case DELETE:
                             case EPOCH:
-                                break;
                             case DESC:
-                                not_in_use_local.push_back(curr_blk);
                                 break;
                             default:
                                 errexit("wrong type of pblk discovered");
@@ -1229,7 +1102,8 @@ namespace pds{
 
         // set system mode back to online
         sys_mode = ONLINE;
-        reset();
+
+        // we postpone reset until init()
 
         std::cout << "returning from EpochSys Recovery." << std::endl;
 #endif /* !MNEMOSYNE */

--- a/src/persist/EpochSys.cpp
+++ b/src/persist/EpochSys.cpp
@@ -570,7 +570,9 @@ namespace pds{
                             } break;
                             case DELETE:
                             case EPOCH:
-                            case DESC: // TODO: allocate DESC in DRAM instead of NVM
+                                break;
+                            case DESC:
+                                not_in_use_local.push_back(curr_blk);
                                 break;
                             default:
                                 errexit("wrong type of pblk discovered");
@@ -1173,7 +1175,9 @@ namespace pds{
                             } break;
                             case DELETE:
                             case EPOCH:
+                                break;
                             case DESC:
+                                not_in_use_local.push_back(curr_blk);
                                 break;
                             default:
                                 errexit("wrong type of pblk discovered");

--- a/src/persist/EpochSys.hpp
+++ b/src/persist/EpochSys.hpp
@@ -115,6 +115,12 @@ public:
     inline bool retired(){
         return retire != nullptr;
     }
+    inline void mark_epoch_container(){
+        id = ~0x0ULL;
+    }
+    inline enum PBlkType get_blktype() {
+        return blktype;
+    }
 };
 
 template<typename T>
@@ -477,9 +483,10 @@ public:
         if (!epoch_container){
             epoch_container = new_pblk<Epoch>();
             epoch_container->blktype = EPOCH;
+            epoch_container->mark_epoch_container();
             global_epoch = &epoch_container->global_epoch;
+            global_epoch->store(INIT_EPOCH, std::memory_order_relaxed);
         }
-        global_epoch->store(INIT_EPOCH, std::memory_order_relaxed);
         parse_env();
     }
 

--- a/src/persist/EpochSys.hpp
+++ b/src/persist/EpochSys.hpp
@@ -388,38 +388,14 @@ public:
     // system mode that toggles on/off PDELETE for recovery purpose.
     SysMode sys_mode = ONLINE;
 
-    EpochSys(GlobalTestConfig* _gtc) : uid_generator(_gtc->task_num), gtc(_gtc) {
+    EpochSys(GlobalTestConfig* _gtc) : uid_generator(_gtc->task_num), gtc(_gtc), task_num(_gtc->task_num) {
         std::string heap_name = get_ralloc_heap_name();
         // task_num+1 to construct Ralloc for dedicated epoch advancer
         _ral = new Ralloc(_gtc->task_num+1,heap_name.c_str(),REGION_SIZE);
-        local_descs = new sc_desc_t* [gtc->task_num];
+        local_descs = new sc_desc_t* [gtc->task_num] {nullptr};
         last_epochs = new padded<uint64_t>[_gtc->task_num];
-        // [wentao] FIXME: this may need to change if recovery reuses
-        // existing descs
-        bool restart=_ral->is_restart();
-        if (restart) {
-            int rec_thd = _gtc->task_num;
-            if (_gtc->checkEnv("RecoverThread")){
-                rec_thd = stoi(_gtc->getEnv("RecoverThread"));
-            }
-            auto begin = chrono::high_resolution_clock::now();
-            recovered = recover(rec_thd);
-            auto end = chrono::high_resolution_clock::now();
-            auto dur = end - begin;
-            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
-        }
-        for(int i=0;i<gtc->task_num;i++){
-            local_descs[i] = new_pblk<sc_desc_t>(i);
-            last_epochs[i].ui = NULL_EPOCH;
-            assert(local_descs[i]!=nullptr);
-            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
-        }
-        persist_func::sfence();
-        if (!restart) {
-            reset();
-        }
-        
+        // desc allocation and potential recovery are all in init()
+
     }
 
     // void flush(){
@@ -455,10 +431,12 @@ public:
         _ral->set_fake_dirty();
         delete _ral;
         delete last_epochs;
+        if(recovered)
+            delete recovered;
         // std::cout<<"Aborted:Total = "<<abort_cnt.load()<<":"<<total_cnt.load()<<std::endl;
     }
 
-    virtual void parse_env();
+    void parse_env();
 
     std::string get_ralloc_heap_name(){
         if (!gtc->checkEnv("HeapName")){
@@ -478,8 +456,7 @@ public:
         return ret;
     }
 
-    virtual void reset(){
-        task_num = gtc->task_num;
+    void reset(){
         if (!epoch_container){
             epoch_container = new_pblk<Epoch>();
             epoch_container->blktype = EPOCH;
@@ -644,7 +621,30 @@ public:
     /////////////
     // Recover //
     /////////////
-    
+    virtual void init() {
+        bool restart=_ral->is_restart();
+        if (restart) {
+            int rec_thd = gtc->task_num;
+            if (gtc->checkEnv("RecoverThread")){
+                rec_thd = stoi(gtc->getEnv("RecoverThread"));
+            }
+            auto begin = chrono::high_resolution_clock::now();
+            recovered = recover(rec_thd);
+            auto end = chrono::high_resolution_clock::now();
+            auto dur = end - begin;
+            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        }
+        for(int i=0;i<gtc->task_num;i++){
+            assert(local_descs[i]==nullptr);
+            local_descs[i] = new_pblk<sc_desc_t>(i);
+            last_epochs[i].ui = NULL_EPOCH;
+            assert(local_descs[i]!=nullptr);
+            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
+        }
+        reset();
+    }
+
     std::unordered_map<uint64_t, PBlk*>* get_recovered() {
         return (recovered);
     }
@@ -660,8 +660,39 @@ class nbEpochSys : public EpochSys {
     // starts in epoch c; this must contain only reset payloads
     void local_persist(uint64_t c);
    public:
-    virtual void reset() override;
-    virtual void parse_env() override;
+    virtual void init() override {
+        bool restart=_ral->is_restart();
+        if (restart) {
+            int rec_thd = gtc->task_num;
+            if (gtc->checkEnv("RecoverThread")){
+                rec_thd = stoi(gtc->getEnv("RecoverThread"));
+            }
+            auto begin = chrono::high_resolution_clock::now();
+            recovered = recover(rec_thd);
+            auto end = chrono::high_resolution_clock::now();
+            auto dur = end - begin;
+            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        }
+        bool reached_all_reused_descs = false; // for debugging
+        for(int i=0;i<gtc->task_num;i++){
+            assert(!reached_all_reused_descs || local_descs[i]==nullptr);
+            if(local_descs[i]==nullptr){
+                reached_all_reused_descs=true;
+                local_descs[i] = new_pblk<sc_desc_t>(i);
+                last_epochs[i].ui = NULL_EPOCH;
+            } else {
+                // this is already a reused desc
+                last_epochs[i].ui = local_descs[i]->epoch;
+            }
+            assert(local_descs[i]!=nullptr);
+            persist_func::clwb_range_nofence(local_descs[i],sizeof(sc_desc_t));
+        }
+        reset();
+        for (int i = 0; i < gtc->task_num; i++) {
+            to_be_persisted->init_desc_local(local_descs[i], i);
+        }
+    }
     virtual uint64_t begin_transaction() override;
     virtual void end_transaction(uint64_t c) override;
     virtual uint64_t begin_reclaim_transaction() override;

--- a/src/persist/EpochSys.hpp
+++ b/src/persist/EpochSys.hpp
@@ -440,6 +440,13 @@ public:
         delete persisted_epochs;
         delete to_be_persisted;
         delete to_be_freed;
+        // Wentao: Due to the lack of snapshotting on transient
+        // indexing, we are unable to do fast recovery from clean
+        // exit for now. 
+        // Remove the following `set_fake_dirty()` routine if we
+        // eventually support snapshot and fast recovery from clean
+        // exit. 
+        _ral->set_fake_dirty();
         delete _ral;
         delete last_epochs;
         // std::cout<<"Aborted:Total = "<<abort_cnt.load()<<":"<<total_cnt.load()<<std::endl;

--- a/src/persist/api/Recoverable.cpp
+++ b/src/persist/api/Recoverable.cpp
@@ -28,6 +28,11 @@ Recoverable::Recoverable(GlobalTestConfig* gtc){
         gtc->setEnv("Liveness", "Blocking");
         _esys = new pds::EpochSys(gtc);
     }
+    auto recovered = _esys->get_recovered();
+    if (recovered) {
+        last_recovered = recovered->size();
+        recover(recovered, false);
+    }
 }
 Recoverable::~Recoverable(){
     delete _esys;

--- a/src/persist/api/Recoverable.cpp
+++ b/src/persist/api/Recoverable.cpp
@@ -28,7 +28,8 @@ Recoverable::Recoverable(GlobalTestConfig* gtc){
         gtc->setEnv("Liveness", "Blocking");
         _esys = new pds::EpochSys(gtc);
     }
-    auto recovered_pblks = _esys->get_recovered();
+    _esys->init();
+    recovered_pblks = _esys->get_recovered();
     if (recovered_pblks) {
         last_recovered_cnt = recovered_pblks->size();
     }
@@ -38,10 +39,7 @@ Recoverable::~Recoverable(){
     delete pending_allocs;
     delete pending_retires;
     delete epochs;
-    if (recovered_pblks) {
-        delete recovered_pblks;
-    }
-    Persistent::finalize();
+    // Persistent::finalize();
 }
 void Recoverable::init_thread(GlobalTestConfig*, LocalTestConfig* ltc){
     pds::EpochSys::init_thread(ltc->tid);

--- a/src/persist/api/Recoverable.cpp
+++ b/src/persist/api/Recoverable.cpp
@@ -28,10 +28,9 @@ Recoverable::Recoverable(GlobalTestConfig* gtc){
         gtc->setEnv("Liveness", "Blocking");
         _esys = new pds::EpochSys(gtc);
     }
-    auto recovered = _esys->get_recovered();
-    if (recovered) {
-        last_recovered = recovered->size();
-        recover(recovered, false);
+    auto recovered_pblks = _esys->get_recovered();
+    if (recovered_pblks) {
+        last_recovered_cnt = recovered_pblks->size();
     }
 }
 Recoverable::~Recoverable(){
@@ -39,6 +38,9 @@ Recoverable::~Recoverable(){
     delete pending_allocs;
     delete pending_retires;
     delete epochs;
+    if (recovered_pblks) {
+        delete recovered_pblks;
+    }
     Persistent::finalize();
 }
 void Recoverable::init_thread(GlobalTestConfig*, LocalTestConfig* ltc){

--- a/src/persist/api/Recoverable.hpp
+++ b/src/persist/api/Recoverable.hpp
@@ -66,9 +66,14 @@ class Recoverable{
     padded<std::vector<pds::PBlk*>>* pending_allocs = nullptr;
     // pending retires; each pair is <original payload, anti-payload>
     padded<std::vector<pair<pds::PBlk*,pds::PBlk*>>>* pending_retires = nullptr;
+    // count of last recovered PBlks from EpochSys
+    uint64_t last_recovered = 0;
 public:
     // return num of blocks recovered.
-    virtual int recover(bool simulated = false) = 0;
+    virtual int recover(std::unordered_map<uint64_t, pds::PBlk*>* recovered, bool simulated = false) {
+        errexit("recover() not implemented. Implement recover() or delete existing persistent heap file.");
+        return 0;
+    }
     Recoverable(GlobalTestConfig* gtc);
     virtual ~Recoverable();
 
@@ -303,8 +308,8 @@ public:
         }
         // _esys->flush();
     }
-    void simulate_crash(){
-        _esys->simulate_crash();
+    uint64_t get_last_recovered_cnt() {
+        return last_recovered;
     }
 
     pds::sc_desc_t* get_dcss_desc(){

--- a/src/persist/api/Recoverable.hpp
+++ b/src/persist/api/Recoverable.hpp
@@ -66,11 +66,13 @@ class Recoverable{
     padded<std::vector<pds::PBlk*>>* pending_allocs = nullptr;
     // pending retires; each pair is <original payload, anti-payload>
     padded<std::vector<pair<pds::PBlk*,pds::PBlk*>>>* pending_retires = nullptr;
+    // pointer to recovered PBlks from EpochSys
+    std::unordered_map<uint64_t, pds::PBlk *>* recovered_pblks = nullptr;
     // count of last recovered PBlks from EpochSys
-    uint64_t last_recovered = 0;
+    uint64_t last_recovered_cnt = 0;
 public:
     // return num of blocks recovered.
-    virtual int recover(std::unordered_map<uint64_t, pds::PBlk*>* recovered, bool simulated = false) {
+    virtual int recover() {
         errexit("recover() not implemented. Implement recover() or delete existing persistent heap file.");
         return 0;
     }
@@ -289,8 +291,11 @@ public:
         assert(epochs[pds::EpochSys::tid].ui != NULL_EPOCH);
         return _esys->openwrite_pblk(b, epochs[pds::EpochSys::tid].ui);
     }
-    std::unordered_map<uint64_t, pds::PBlk*>* recover_pblks(const int rec_thd=10){
-        return _esys->recover(rec_thd);
+    std::unordered_map<uint64_t, pds::PBlk*>* get_recovered_pblks(){
+        return recovered_pblks;
+    }
+    uint64_t get_last_recovered_cnt() {
+        return last_recovered_cnt;
     }
     void sync(){
         assert(epochs[pds::EpochSys::tid].ui == NULL_EPOCH);
@@ -307,9 +312,6 @@ public:
             sync();
         }
         // _esys->flush();
-    }
-    uint64_t get_last_recovered_cnt() {
-        return last_recovered;
     }
 
     pds::sc_desc_t* get_dcss_desc(){

--- a/src/persist/api/montage_global_api.hpp
+++ b/src/persist/api/montage_global_api.hpp
@@ -10,23 +10,9 @@
 
 namespace pds{
     class GlobalRecoverable: public Recoverable{
-        std::unordered_map<uint64_t, PBlk*>* recovered_pblks = nullptr;
     public:
         GlobalRecoverable(GlobalTestConfig* gtc): Recoverable(gtc){}
-        ~GlobalRecoverable(){
-            if (recovered_pblks){
-                delete recovered_pblks;
-            }
-        }
-        int recover(bool simulated){
-            // TODO: handle simulated situation here?
-            recovered_pblks = recover_pblks();
-            // TODO: return number of blocks here?
-            return 0;
-        }
-        std::unordered_map<uint64_t, PBlk*>* get_recovered(){
-            return recovered_pblks;
-        }
+        ~GlobalRecoverable(){}
     };
 
     extern GlobalRecoverable* global_recoverable;
@@ -117,9 +103,8 @@ namespace pds{
     //         delete(b);
     //     }})
 
-    inline std::unordered_map<uint64_t, PBlk*>* recover(const int rec_thd=10){
-        global_recoverable->recover(rec_thd);
-        return global_recoverable->get_recovered();
+    inline std::unordered_map<uint64_t, PBlk*>* get_recovered_pblks(){
+        return global_recoverable->get_recovered_pblks();
     }
 
     inline void flush(){

--- a/src/rideables/HOHHashTable.hpp
+++ b/src/rideables/HOHHashTable.hpp
@@ -58,7 +58,7 @@ public:
         }
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of HOHHashTable not implemented");
     }
 

--- a/src/rideables/MontageGraph.hpp
+++ b/src/rideables/MontageGraph.hpp
@@ -126,6 +126,11 @@ class MontageGraph : public RGraph, public Recoverable{
         };
 
         MontageGraph(GlobalTestConfig* gtc) : Recoverable(gtc), gtc(gtc) {
+            if (get_recovered_pblks()) {
+                recover();
+                return;
+            }
+
             size_t sz = numVertices;
             this->vMeta = new VertexMeta[numVertices];
             std::mt19937_64 gen(time(NULL));
@@ -168,7 +173,9 @@ class MontageGraph : public RGraph, public Recoverable{
             if(gtc->verbose) std::cout << "Filled mean edges per vertex" << std::endl;
         }
 
-        ~MontageGraph() {}
+        ~MontageGraph() {
+            delete vMeta;
+        }
         
 	// Obtain statistics of graph (|V|, |E|, average degree, vertex degrees)
         // Not concurrent safe...
@@ -329,35 +336,23 @@ class MontageGraph : public RGraph, public Recoverable{
             return ret;
         }
         
-        int recover(bool simulated) {
+        int recover() {
             struct RelationWrapper{
                 int v1;
                 int v2;
                 Relation* e;
             } __attribute__((aligned(CACHE_LINE_SIZE)));
 
-            // assert(0&&"recover() not implemented!");
-            if (simulated) {
-                recover_mode();
-                delete vMeta;
-                vMeta = new VertexMeta[numVertices];
-                // #pragma omp parallel for
-                for (size_t i = 0; i < numVertices; i++) {
-                     vertex(i) = nullptr;
-                }
-                online_mode();
+            vMeta = new VertexMeta[numVertices];
+            for (size_t i = 0; i < numVertices; i++) {
+                vertex(i) = nullptr;
             }
-
             int rec_thd = gtc->task_num; 
             int block_cnt = 0;
-            auto begin = chrono::high_resolution_clock::now();
-            std::unordered_map<uint64_t, pds::PBlk*>* recovered = recover_pblks();
-            auto end = chrono::high_resolution_clock::now();
-            auto dur = end - begin;
-            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-            std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+            std::unordered_map<uint64_t, pds::PBlk*>* recovered = get_recovered_pblks();
+            assert(recovered);
             
-            begin = chrono::high_resolution_clock::now();
+            auto begin = chrono::high_resolution_clock::now();
             std::vector<Relation*> relationVector;
             std::vector<Vertex*> vertexVector;
             {
@@ -389,9 +384,9 @@ class MontageGraph : public RGraph, public Recoverable{
                     }
                 }
             }
-            end = chrono::high_resolution_clock::now();
-            dur = end - begin;
-            dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
+            auto end = chrono::high_resolution_clock::now();
+            auto dur = end - begin;
+            auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
             std::cout << "Spent " << dur_ms << "ms gathering vertices(" << vertexVector.size() << ") and edges(" << relationVector.size() << ")..." << std::endl;
             begin = chrono::high_resolution_clock::now();
 

--- a/src/rideables/MontageGraph.hpp
+++ b/src/rideables/MontageGraph.hpp
@@ -529,7 +529,6 @@ class MontageGraph : public RGraph, public Recoverable{
             std::cout << "Spent " << dur_ms << "ms forming edges..." << std::endl;
             begin = chrono::high_resolution_clock::now();
 
-            delete recovered;
             return block_cnt;
 	}
 

--- a/src/rideables/MontageHashTable.hpp
+++ b/src/rideables/MontageHashTable.hpp
@@ -62,7 +62,11 @@ public:
     std::hash<K> hash_fn;
     Bucket buckets[idxSize];
     GlobalTestConfig* gtc;
-    MontageHashTable(GlobalTestConfig* gtc_): Recoverable(gtc_), gtc(gtc_){};
+    MontageHashTable(GlobalTestConfig* gtc_): Recoverable(gtc_), gtc(gtc_){
+        if (get_recovered_pblks()) {
+            recover();
+        }
+    };
 
     void init_thread(GlobalTestConfig* gtc, LocalTestConfig* ltc){
         Recoverable::init_thread(gtc, ltc);
@@ -200,14 +204,8 @@ public:
     }
 
 
-    int recover(std::unordered_map<uint64_t, pds::PBlk*>* recovered, bool simulated){
-        if (simulated){
-            recover_mode(); // PDELETE --> noop
-            // clear transient structures.
-            clear();
-            online_mode(); // re-enable PDELETE.
-        }
-
+    int recover(){
+        std::unordered_map<uint64_t, pds::PBlk*>* recovered = get_recovered_pblks();
         assert(recovered);
 
         int rec_cnt = 0;

--- a/src/rideables/MontageHashTable.hpp
+++ b/src/rideables/MontageHashTable.hpp
@@ -68,6 +68,13 @@ public:
         }
     };
 
+    ~MontageHashTable() {
+        recover_mode(); // PDELETE --> noop
+        // clear transient structures.
+        clear();
+        online_mode(); // re-enable PDELETE.
+    }
+
     void init_thread(GlobalTestConfig* gtc, LocalTestConfig* ltc){
         Recoverable::init_thread(gtc, ltc);
     }

--- a/src/rideables/MontageHashTable.hpp
+++ b/src/rideables/MontageHashTable.hpp
@@ -33,7 +33,7 @@ public:
         ListNode(MontageHashTable* ds_, K key, V val): ds(ds_){
             payload = ds->pnew<Payload>(key, val);
         }
-        ListNode(Payload* _payload) : payload(_payload) {} // for recovery
+        ListNode(MontageHashTable* ds_, Payload* _payload) : ds(ds_), payload(_payload) {} // for recovery
         K get_key(){
             assert(payload!=nullptr && "payload shouldn't be null");
             // old-see-new never happens for locking ds
@@ -235,7 +235,7 @@ public:
                                   HWLOC_CPUBIND_THREAD);
                 for (size_t i = rec_tid; i < payloadVector.size(); i += rec_thd){
                     //re-insert payload.
-                    ListNode* new_node = new ListNode(payloadVector[i]);
+                    ListNode* new_node = new ListNode(this, payloadVector[i]);
                     K key = new_node->get_key();
                     size_t idx = hash_fn(key) % idxSize;
                     std::lock_guard<std::mutex> lk(buckets[idx].lock);
@@ -267,7 +267,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        delete recovered;
         return rec_cnt;
     }
 };

--- a/src/rideables/MontageLfHashTable.hpp
+++ b/src/rideables/MontageLfHashTable.hpp
@@ -50,7 +50,7 @@ private:
             payload = ds->pnew<Payload>(k,v);
             // assert(ds->epochs[pds::EpochSys::tid].ui == NULL_EPOCH);
             };
-        Node(Payload* _payload) : payload(_payload),key(_payload->get_unsafe_key(ds)) {} // for recovery
+        Node(MontageLfHashTable* ds_, Payload* _payload) : ds(ds_), payload(_payload),key(_payload->get_unsafe_key(ds)) {} // for recovery
         K get_key(){
             return key;
         }
@@ -153,7 +153,7 @@ public:
                                   HWLOC_CPUBIND_THREAD);
                 for (size_t i = rec_tid; i < payloadVector.size(); i += rec_thd) {
                     // re-insert payload.
-                    Node* tmpNode = new Node(payloadVector[i]);
+                    Node* tmpNode = new Node(this, payloadVector[i]);
                     K key = tmpNode->get_key();
                     size_t idx = hash_fn(key) % idxSize;
                     MarkPtr* prev = nullptr;
@@ -185,7 +185,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        delete recovered;
         return rec_cnt;
     }
 

--- a/src/rideables/MontageLfHashTable.hpp
+++ b/src/rideables/MontageLfHashTable.hpp
@@ -95,8 +95,16 @@ private:
     }
 public:
     MontageLfHashTable(GlobalTestConfig* gtc) : Recoverable(gtc), tracker(gtc->task_num, 100, 1000, true), gtc(gtc) {
+        if (get_recovered_pblks()) {
+            recover();
+        }
     };
-    ~MontageLfHashTable(){};
+    ~MontageLfHashTable(){
+        recover_mode(); // PDELETE --> noop
+        // clear transient structures.
+        clear();
+        online_mode(); // re-enable PDELETE.
+    };
 
     void init_thread(GlobalTestConfig* gtc, LocalTestConfig* ltc){
         Recoverable::init_thread(gtc, ltc);
@@ -114,35 +122,25 @@ public:
             buckets[i].ui.ptr.store(this,nullptr);
         }
     }
-    int recover(bool simulated){
-        if (simulated){
-            recover_mode(); // PDELETE --> noop
-            // clear transient structures.
-            clear();
-            online_mode(); // re-enable PDELETE.
-        }
-
+    int recover(){
         int rec_cnt = 0;
         int rec_thd = gtc->task_num;
         if (gtc->checkEnv("RecoverThread")){
             rec_thd = stoi(gtc->getEnv("RecoverThread"));
         }
-        auto begin = chrono::high_resolution_clock::now();
-        std::unordered_map<uint64_t, pds::PBlk*>* recovered = recover_pblks(rec_thd); 
-        auto end = chrono::high_resolution_clock::now();
-        auto dur = end - begin;
-        auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-        std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        std::unordered_map<uint64_t, pds::PBlk*>* recovered = get_recovered_pblks(); 
+        assert(recovered);
+
         std::vector<Payload*> payloadVector;
         payloadVector.reserve(recovered->size());
-        begin = chrono::high_resolution_clock::now();
+        auto begin = chrono::high_resolution_clock::now();
         for (auto itr = recovered->begin(); itr != recovered->end(); itr++){
             rec_cnt++;
             Payload* payload = reinterpret_cast<Payload*>(itr->second);
             payloadVector.push_back(payload);
         }
-        end = chrono::high_resolution_clock::now();
-        dur = end - begin;
+        auto end = chrono::high_resolution_clock::now();
+        auto dur = end - begin;
         auto dur_ms_vec = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_vec << "ms building vector" << std::endl;
         begin = chrono::high_resolution_clock::now();
@@ -187,7 +185,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        std::cout << "Total time to recover: " << dur_ms+dur_ms_vec+dur_ms_ins << "ms" << std::endl;
         delete recovered;
         return rec_cnt;
     }

--- a/src/rideables/MontageLfSkipList.hpp
+++ b/src/rideables/MontageLfSkipList.hpp
@@ -149,8 +149,15 @@ public:
         int bg_tid = gtc->task_num;
         bg_state.store(background_state::RUNNING);
         background_thread = std::move(std::thread(&MontageLfSkipList::bg_loop, this, bg_tid));
+        if (get_recovered_pblks()) {
+            recover();
+        }
     };
     ~MontageLfSkipList(){
+        recover_mode(); // PDELETE --> noop
+        // clear transient structures.
+        clear();
+        online_mode(); // re-enable PDELETE.
         bg_state.store(background_state::FINISHED);
         background_thread.join();
     };
@@ -180,14 +187,7 @@ public:
         head.ptr.store(initialHeadNode);
     }
 
-    int recover(bool simulated){
-        if (simulated){
-            recover_mode(); // PDELETE --> noop
-            // clear transient structures.
-            clear();
-            online_mode(); // re-enable PDELETE.
-        }
-
+    int recover(){
         should_cas_verify.store(false);
 
         int rec_cnt = 0;
@@ -195,23 +195,18 @@ public:
         if (gtc->checkEnv("RecoverThread")){
             rec_thd_count = stoi(gtc->getEnv("RecoverThread"));
         }
-        auto begin = chrono::high_resolution_clock::now();
-        std::unordered_map<uint64_t, pds::PBlk*>* recovered = recover_pblks(rec_thd_count);
-        auto end = chrono::high_resolution_clock::now();
-        auto dur = end - begin;
-        auto dur_ms = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
-        std::cout << "Spent " << dur_ms << "ms getting PBlk(" << recovered->size() << ")" << std::endl;
+        std::unordered_map<uint64_t, pds::PBlk*>* recovered = get_recovered_pblks();
 
         std::vector<Payload*> payloadVector;
         payloadVector.reserve(recovered->size());
-        begin = chrono::high_resolution_clock::now();
+        auto begin = chrono::high_resolution_clock::now();
         for (auto itr = recovered->begin(); itr != recovered->end(); itr++){
             rec_cnt++;
             Payload* payload = reinterpret_cast<Payload*>(itr->second);
             payloadVector.push_back(payload);
         }
-        end = chrono::high_resolution_clock::now();
-        dur = end - begin;
+        auto end = chrono::high_resolution_clock::now();
+        auto dur = end - begin;
         auto dur_ms_vec = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_vec << "ms building vector" << std::endl;
 
@@ -253,7 +248,6 @@ public:
         dur = end - begin;
         auto dur_ms_ins = std::chrono::duration_cast<std::chrono::milliseconds>(dur).count();
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
-        std::cout << "Total time to recover: " << dur_ms+dur_ms_vec+dur_ms_ins << "ms" << std::endl;
 
         should_cas_verify.store(true);
         delete recovered;

--- a/src/rideables/MontageLfSkipList.hpp
+++ b/src/rideables/MontageLfSkipList.hpp
@@ -250,7 +250,6 @@ public:
         std::cout << "Spent " << dur_ms_ins << "ms inserting(" << recovered->size() << ")" << std::endl;
 
         should_cas_verify.store(true);
-        delete recovered;
         return rec_cnt;
     }
 

--- a/src/rideables/MontageMSQueue.hpp
+++ b/src/rideables/MontageMSQueue.hpp
@@ -71,7 +71,7 @@ public:
         Recoverable::init_thread(gtc, ltc);
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of MontageMSQueue not implemented.");
         return 0;
     }

--- a/src/rideables/MontageNatarajanTree.hpp
+++ b/src/rideables/MontageNatarajanTree.hpp
@@ -163,7 +163,7 @@ public:
         Recoverable::init_thread(gtc, ltc);
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of MontageNatarajanTree not implemented.");
         return 0;
     }

--- a/src/rideables/MontageQueue.hpp
+++ b/src/rideables/MontageQueue.hpp
@@ -76,7 +76,7 @@ public:
         Recoverable::init_thread(gtc, ltc);
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of MontageQueue not implemented.");
         return 0;
     }

--- a/src/rideables/MontageSSHashTable.hpp
+++ b/src/rideables/MontageSSHashTable.hpp
@@ -124,7 +124,7 @@ public:
         Recoverable::init_thread(gtc, ltc);
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of MontageSSHashTable not implemented.");
         return 0;
     }

--- a/src/rideables/UnbalancedTree.hpp
+++ b/src/rideables/UnbalancedTree.hpp
@@ -68,7 +68,7 @@ public:
         root = nullptr;
     }
 
-    int recover(bool simulated){
+    int recover(){
         errexit("recover of UnbalancedTree not implemented");
         return 0;
     }

--- a/src/tests/AllocTest.hpp
+++ b/src/tests/AllocTest.hpp
@@ -25,7 +25,7 @@ class DummyObject : public pds::PBlk {
 };
 
 struct MontageDummy : public Recoverable {
-    int recover(bool simulated) { return 0; }
+    int recover() { return 0; }
     MontageDummy(GlobalTestConfig *gtc) : Recoverable(gtc) {}
     ~MontageDummy() {}
 

--- a/src/tests/RecoverVerifyTest.hpp
+++ b/src/tests/RecoverVerifyTest.hpp
@@ -14,6 +14,7 @@
 template <class K, class V>
 class RecoverVerifyTest : public Test{
 public:
+    GlobalTestConfig* _gtc;
     RMap<K,V>* m;
     Recoverable* rec;
     size_t ins_cnt = 1000000;
@@ -21,13 +22,14 @@ public:
     size_t key_size = TESTS_KEY_SIZE;
     size_t val_size = TESTS_VAL_SIZE;
     pthread_barrier_t sync_point;
-    RecoverVerifyTest(){}
+    RecoverVerifyTest(GlobalTestConfig* gtc): _gtc(gtc){}
     void init(GlobalTestConfig* gtc);
     void parInit(GlobalTestConfig* gtc, LocalTestConfig* ltc);
     int execute(GlobalTestConfig* gtc, LocalTestConfig* ltc);
     void cleanup(GlobalTestConfig* gtc);
 
     inline K fromInt(uint64_t v);
+    void prepareRideable();
 };
 
 template <class K, class V>
@@ -36,9 +38,8 @@ void RecoverVerifyTest<K,V>::parInit(GlobalTestConfig* gtc, LocalTestConfig* ltc
 }
 
 template <class K, class V>
-void RecoverVerifyTest<K,V>::init(GlobalTestConfig* gtc){
-
-    Rideable* ptr = gtc->allocRideable();
+void RecoverVerifyTest<K,V>::prepareRideable() {
+    Rideable* ptr = _gtc->allocRideable();
     m = dynamic_cast<RMap<K,V>*>(ptr);
     if (!m) {
         errexit("RecoverVerifyTest must be run on RMap<K,V> type object.");
@@ -47,6 +48,11 @@ void RecoverVerifyTest<K,V>::init(GlobalTestConfig* gtc){
     if (!rec){
         errexit("RecoverVerifyTest must be run on Recoverable type object.");
     }
+}
+
+template <class K, class V>
+void RecoverVerifyTest<K,V>::init(GlobalTestConfig* gtc){
+    prepareRideable();
     if (gtc->checkEnv("InsCnt")){
         ins_cnt = stoll(gtc->getEnv("InsCnt"));
         range = ins_cnt * 10;
@@ -71,6 +77,7 @@ inline std::string RecoverVerifyTest<std::string,std::string>::fromInt(uint64_t 
 template <class K, class V>
 int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc){
     std::string value_buffer; // for string kv only
+    gtc->setEnv("HeapName", "RecoveryVerifyTest");
     if (!gtc->checkEnv("NoVerify")){
         if (ltc->tid == 0){ // FIXME: workaround when we can't change the total thread count of ralloc.
             std::unordered_map<K,V> reference;
@@ -114,10 +121,11 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
             std::cout<<"insert finished. Spent "<< dur_ms << "ms" <<std::endl;
             rec->flush();
             std::cout<<"epochsys flushed."<<std::endl;
-            rec->simulate_crash();
+            delete m;
             std::cout<<"crashed."<<std::endl;
-            int rec_cnt = rec->recover(true);
+            prepareRideable();
             std::cout<<"recover returned."<<std::endl;
+            auto rec_cnt = rec->get_last_recovered_cnt();
             if (rec_cnt == (int)reference.size()){
                 std::cout<<"rec_cnt currect."<<std::endl;
             } else {
@@ -177,9 +185,9 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
         if(tid==0){
             rec->flush();
             std::cout<<"epochsys flushed."<<std::endl;
-            rec->simulate_crash();
+            delete m;
             std::cout<<"crashed."<<std::endl;
-            int rec_cnt = rec->recover(true);
+            prepareRideable();
             std::cout<<"recover returned."<<std::endl;
         }
         return ops;

--- a/src/tests/RecoverVerifyTest.hpp
+++ b/src/tests/RecoverVerifyTest.hpp
@@ -126,7 +126,7 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
             prepareRideable();
             std::cout<<"recover returned."<<std::endl;
             auto rec_cnt = rec->get_last_recovered_cnt();
-            if (rec_cnt == (int)reference.size()){
+            if (rec_cnt == reference.size()){
                 std::cout<<"rec_cnt currect."<<std::endl;
             } else {
                 std::cout<<"recovered:"<<rec_cnt<<" expecting:"<<reference.size()<<std::endl;

--- a/src/tests/RecoverVerifyTest.hpp
+++ b/src/tests/RecoverVerifyTest.hpp
@@ -77,7 +77,6 @@ inline std::string RecoverVerifyTest<std::string,std::string>::fromInt(uint64_t 
 template <class K, class V>
 int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc){
     std::string value_buffer; // for string kv only
-    gtc->setEnv("HeapName", "RecoveryVerifyTest");
     if (!gtc->checkEnv("NoVerify")){
         if (ltc->tid == 0){ // FIXME: workaround when we can't change the total thread count of ralloc.
             std::unordered_map<K,V> reference;
@@ -130,6 +129,7 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
                 std::cout<<"rec_cnt currect."<<std::endl;
             } else {
                 std::cout<<"recovered:"<<rec_cnt<<" expecting:"<<reference.size()<<std::endl;
+                std::cout<<"Test FAILED!"<<std::endl;
                 exit(1);
             }
             
@@ -140,6 +140,7 @@ int RecoverVerifyTest<K,V>::execute(GlobalTestConfig* gtc, LocalTestConfig* ltc)
                 }
             }
             std::cout<<"all records recovered."<<std::endl;
+            std::cout<<"Test PASSED!"<<std::endl;
             return ops;
         } else {
             return 0;

--- a/src/utils/RCUTracker.hpp
+++ b/src/utils/RCUTracker.hpp
@@ -25,6 +25,7 @@ limitations under the License.
 #include <list>
 #include <vector>
 #include <atomic>
+#include <functional>
 #include "ConcurrentPrimitives.hpp"
 
 #include "BaseTracker.hpp"


### PR DESCRIPTION
`Recoverable::recover()` used to be called in experimental tests. Now we moved the logic into constructor of `Recoverable` and requests all data structures to implement it. Now every `Recoverable` checks for heap file with name defined in env "HeapName". If the file exists, it runs recovery procedure in `Ralloc`, `EpochSys` and `Recoverable` descendants in turn.